### PR TITLE
Fix Multi-Account admin tab layout consistency, notices order, and Woo settings UI regressions

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-express-checkout.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-express-checkout.php
@@ -2334,7 +2334,8 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_Express_Checkout {
     public function own_woocommerce_order_item_add_action_buttons($order) {
         $angelleye_multi_account_ec_parallel_data_map = $order->get_meta('_angelleye_multi_account_ec_parallel_data_map', true);
         if (!empty($angelleye_multi_account_ec_parallel_data_map)) {
-            echo sprintf('<br><span class="description"><span class="woocommerce-help-tip" data-tip="%s"></span>%s</span>', MULTI_ACCOUNT_REFUND_NOTICE, MULTI_ACCOUNT_REFUND_NOTICE);
+            $refund_notice = angelleye_pfwma_get_multi_account_refund_notice();
+            echo sprintf('<br><span class="description"><span class="woocommerce-help-tip" data-tip="%s"></span>%s</span>', $refund_notice, $refund_notice);
         }
     }
 

--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -124,6 +124,29 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
         } else {
             $this->decimals = 2;
         }
+        // Avoid triggering PPCP translation defaults before init.
+        $this->bootstrap_ppcp_settings_from_options();
+        if (did_action('init')) {
+            $this->bootstrap_ppcp_settings_from_gateway();
+        } else {
+            add_action('init', array($this, 'bootstrap_ppcp_settings_from_gateway'), 1);
+        }
+    }
+
+    public function bootstrap_ppcp_settings_from_options() {
+        $this->settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+        $this->is_sandbox = isset($this->settings['testmode']) && 'yes' === $this->settings['testmode'];
+        $this->invoice_prefix = !empty($this->settings['invoice_prefix']) ? $this->settings['invoice_prefix'] : 'WC-PPCP';
+        $this->sandbox_client_id = isset($this->settings['sandbox_client_id']) ? $this->settings['sandbox_client_id'] : '';
+        $this->sandbox_secret_id = isset($this->settings['sandbox_api_secret']) ? $this->settings['sandbox_api_secret'] : '';
+        $this->live_client_id = isset($this->settings['api_client_id']) ? $this->settings['api_client_id'] : '';
+        $this->live_secret_id = isset($this->settings['api_secret']) ? $this->settings['api_secret'] : '';
+        $this->sandbox_merchant_id = isset($this->settings['sandbox_merchant_id']) ? $this->settings['sandbox_merchant_id'] : '';
+        $this->live_merchant_id = isset($this->settings['live_merchant_id']) ? $this->settings['live_merchant_id'] : '';
+        $this->bootstrap_ppcp_settings_set_runtime_credentials();
+    }
+
+    public function bootstrap_ppcp_settings_from_gateway() {
         if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
             include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php';
         }
@@ -136,6 +159,10 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
         $this->live_secret_id = $this->settings->get('api_secret', '');
         $this->sandbox_merchant_id = $this->settings->get('sandbox_merchant_id', '');
         $this->live_merchant_id = $this->settings->get('live_merchant_id', '');
+        $this->bootstrap_ppcp_settings_set_runtime_credentials();
+    }
+
+    private function bootstrap_ppcp_settings_set_runtime_credentials() {
         if ($this->is_sandbox) {
             $this->client_id = $this->sandbox_client_id;
             $this->secret_id = $this->sandbox_secret_id;
@@ -2153,7 +2180,8 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
         $order_id = version_compare(WC_VERSION, '3.0', '<') ? $order->id : $order->get_id();
         $angelleye_multi_account_ppcp_parallel_data_map = $order->get_meta('_angelleye_multi_account_ppcp_parallel_data_map', true);
         if (!empty($angelleye_multi_account_ppcp_parallel_data_map)) {
-            echo sprintf('<br><span class="description"><span class="woocommerce-help-tip" data-tip="%s"></span>%s</span>', MULTI_ACCOUNT_REFUND_NOTICE, MULTI_ACCOUNT_REFUND_NOTICE);
+            $refund_notice = angelleye_pfwma_get_multi_account_refund_notice();
+            echo sprintf('<br><span class="description"><span class="woocommerce-help-tip" data-tip="%s"></span>%s</span>', $refund_notice, $refund_notice);
         }
     }
 

--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -126,15 +126,14 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
         }
         // Avoid triggering PPCP translation defaults before init.
         $this->bootstrap_ppcp_settings_from_options();
-        if (did_action('init')) {
-            $this->bootstrap_ppcp_settings_from_gateway();
-        } else {
-            add_action('init', array($this, 'bootstrap_ppcp_settings_from_gateway'), 1);
-        }
     }
 
     public function bootstrap_ppcp_settings_from_options() {
-        $this->settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+        if (function_exists('angelleye_pfw_get_ppcp_settings')) {
+            $this->settings = angelleye_pfw_get_ppcp_settings();
+        } else {
+            $this->settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+        }
         $this->is_sandbox = isset($this->settings['testmode']) && 'yes' === $this->settings['testmode'];
         $this->invoice_prefix = !empty($this->settings['invoice_prefix']) ? $this->settings['invoice_prefix'] : 'WC-PPCP';
         $this->sandbox_client_id = isset($this->settings['sandbox_client_id']) ? $this->settings['sandbox_client_id'] : '';
@@ -143,22 +142,6 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
         $this->live_secret_id = isset($this->settings['api_secret']) ? $this->settings['api_secret'] : '';
         $this->sandbox_merchant_id = isset($this->settings['sandbox_merchant_id']) ? $this->settings['sandbox_merchant_id'] : '';
         $this->live_merchant_id = isset($this->settings['live_merchant_id']) ? $this->settings['live_merchant_id'] : '';
-        $this->bootstrap_ppcp_settings_set_runtime_credentials();
-    }
-
-    public function bootstrap_ppcp_settings_from_gateway() {
-        if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
-            include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php';
-        }
-        $this->settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
-        $this->is_sandbox = 'yes' === $this->settings->get('testmode', 'no');
-        $this->invoice_prefix = $this->settings->get('invoice_prefix', 'WC-PPCP');
-        $this->sandbox_client_id = $this->settings->get('sandbox_client_id', '');
-        $this->sandbox_secret_id = $this->settings->get('sandbox_api_secret', '');
-        $this->live_client_id = $this->settings->get('api_client_id', '');
-        $this->live_secret_id = $this->settings->get('api_secret', '');
-        $this->sandbox_merchant_id = $this->settings->get('sandbox_merchant_id', '');
-        $this->live_merchant_id = $this->settings->get('live_merchant_id', '');
         $this->bootstrap_ppcp_settings_set_runtime_credentials();
     }
 

--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin.php
@@ -100,7 +100,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
         $selected_role = '';
         $ec_site_owner_commission = 0;
         $microprocessing = get_post_meta($_GET['ID']);
-        echo '<br/><div class="angelleye_multi_account_left"><form method="post" id="angelleye_multi_account" action="" enctype="multipart/form-data"><table class="form-table">
+        echo '<br/><div class="angelleye_multi_account_layout"><div class="angelleye_multi_account_left"><form method="post" id="angelleye_multi_account" action="" enctype="multipart/form-data"><table class="form-table">
         <tbody class="angelleye_micro_account_body">';
         $gateway_list = array();
         if (class_exists('AngellEYE_Gateway_Paypal')) {
@@ -743,6 +743,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
                                 </tr>', $_GET['ID'], __('Save Changes', 'paypal-for-woocommerce-multi-account-management'), __('Cancel', 'paypal-for-woocommerce-multi-account-management'), wp_nonce_field('microprocessing_save'));
         echo '</tbody></table></form></div>';
         $this->angelleye_multi_account_tooltip_box();
+        echo '</div>';
     }
 
     public function angelleye_multi_account_settings_fields() {
@@ -1041,7 +1042,6 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
             </div>
         </div>
         <?php
-        $this->angelleye_pfwma_display_marketing_sidebar();
     }
 
     public function angelleye_multi_account_tooltip_box() {
@@ -1098,34 +1098,36 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
         if (empty($_GET['action'])) {
             ?>
             <br/>
-            <div class="angelleye_multi_account_left">
-                <form method="post" id="angelleye_multi_account" action="" enctype="multipart/form-data">
-                    <table class="form-table" id="micro_account_fields" >
-                        <tbody class="angelleye_micro_account_body">
-                            <?php echo $this->angelleye_multi_account_choose_payment_gateway(); ?>
-                            <?php echo $this->angelleye_multi_account_api_field_ui() ?>
-                            <?php echo $this->angelleye_multi_account_paypal_pro_payflow_api_field_ui(); ?>
-                            <?php echo $this->angelleye_multi_account_api_paypal_field_ui(); ?>
-                            <?php echo $this->angelleye_multi_account_api_angelleye_ppcp_field_ui(); ?>
-                            <?php
-                            $angelleye_payment_load_balancer = get_option('angelleye_payment_load_balancer', '');
-                            if ($angelleye_payment_load_balancer == '') {
-                                echo $this->angelleye_multi_account_condition_ui();
-                            }
-                            ?>
-                            <tr valign="top">
-                                <td scope="row" class="titledesc">
-                                    <input id="microprocessing_save" name="microprocessing_save" class="button-primary" type="submit" value="<?php esc_attr_e('Save Changes', 'paypal-for-woocommerce-multi-account-management'); ?>" />
-                                    <a href="?page=wc-settings&tab=multi_account_management" class="button-primary button"><?php esc_attr_e('Cancel', 'paypal-for-woocommerce-multi-account-management'); ?></a>
-                                    <?php wp_nonce_field('microprocessing_save'); ?>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </form>
+            <div class="angelleye_multi_account_layout">
+                <div class="angelleye_multi_account_left">
+                    <form method="post" id="angelleye_multi_account" action="" enctype="multipart/form-data">
+                        <table class="form-table" id="micro_account_fields" >
+                            <tbody class="angelleye_micro_account_body">
+                                <?php echo $this->angelleye_multi_account_choose_payment_gateway(); ?>
+                                <?php echo $this->angelleye_multi_account_api_field_ui() ?>
+                                <?php echo $this->angelleye_multi_account_paypal_pro_payflow_api_field_ui(); ?>
+                                <?php echo $this->angelleye_multi_account_api_paypal_field_ui(); ?>
+                                <?php echo $this->angelleye_multi_account_api_angelleye_ppcp_field_ui(); ?>
+                                <?php
+                                $angelleye_payment_load_balancer = get_option('angelleye_payment_load_balancer', '');
+                                if ($angelleye_payment_load_balancer == '') {
+                                    echo $this->angelleye_multi_account_condition_ui();
+                                }
+                                ?>
+                                <tr valign="top">
+                                    <td scope="row" class="titledesc">
+                                        <input id="microprocessing_save" name="microprocessing_save" class="button-primary" type="submit" value="<?php esc_attr_e('Save Changes', 'paypal-for-woocommerce-multi-account-management'); ?>" />
+                                        <a href="?page=wc-settings&tab=multi_account_management" class="button-primary button"><?php esc_attr_e('Cancel', 'paypal-for-woocommerce-multi-account-management'); ?></a>
+                                        <?php wp_nonce_field('microprocessing_save'); ?>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </form>
+                </div>
+                <?php $this->angelleye_multi_account_tooltip_box(); ?>
             </div>
             <?php
-            $this->angelleye_multi_account_tooltip_box();
         } elseif (!empty($_GET['action']) && $_GET['action'] == 'edit') {
             $this->angelleye_display_multi_account_list();
         }
@@ -1193,6 +1195,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
             if (isset($deactive_count) && $deactive_count !== false) {
                 ?> <a class="page-title-action enable_all_vendor_rules"><?php echo __('Enable All Auto-generated Vendor Rules', 'paypal-for-woocommerce-multi-account-management'); ?></a> <?php
             }
+            echo '<div></div>';
             if (class_exists('Paypal_For_Woocommerce_Multi_Account_Management_List_Data')) {
                 $table = new Paypal_For_Woocommerce_Multi_Account_Management_List_Data();
                 $table->prepare_items();
@@ -1225,6 +1228,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
         <div id="angelleye_paypal_marketing_table">
         <br>
         <h1 class="wp-heading-inline"><?php echo __('PayPal Payment Distribution Report', ''); ?></h1>
+        <?php echo '<div></div>'; ?>
         <?php
         if (class_exists('PFWMA_Payments_History_List')) {
             $table = new PFWMA_Payments_History_List();

--- a/admin/css/paypal-for-woocommerce-multi-account-management-admin.css
+++ b/admin/css/paypal-for-woocommerce-multi-account-management-admin.css
@@ -8,33 +8,49 @@
     width: 460px;
 }
 .angelleye_multi_account_left {
-    max-width: 60%;
-    float: left;
-    width: 688px;
+    max-width: 100%;
+    width: auto;
+    flex: 1 1 680px;
+    min-width: 0;
+}
+.angelleye_multi_account_left .form-table {
+    width: 100%;
 }
 
 .angelleye_multi_account_right {
-    max-width: 475px;
-    float: left;
+    max-width: 420px;
     padding: 10px;
     border: 1px solid #d1c6c6;
     border-radius: 15px;
     display: block;
-    margin-top: 0px;
-    margin-left: 10px;
-    width: 37%;
+    margin-top: 0;
+    margin-left: 0;
+    width: 100%;
+    flex: 1 1 320px;
 }
 .angelleye_multi_global_commission_right {
-    max-width: 475px;
-    float: left;
+    max-width: 420px;
     padding: 10px;
     border: 1px solid #d1c6c6;
     border-radius: 15px;
     display: block;
-    margin-top: 0px;
+    margin-top: 0;
     margin-left: 10px;
-    width: 37%;
+    width: 100%;
+    flex: 1 1 320px;
     margin-bottom: 20px;
+}
+.angelleye_multi_account_layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-start;
+}
+.angelleye_pfwma_admin_shell .angelleye_multi_account_global_setting {
+    width: 100%;
+}
+.angelleye_pfwma_admin_content {
+    width: 100%;
 }
 .angelleye_multi_global_commission_right label.commission {
     width: 215px;
@@ -155,8 +171,8 @@ select.smart_forwarding_field {
     text-overflow: ellipsis;
 }
 
-#angelleye_paypal_marketing_table table.fixed {
-    border-right: none;
+#angelleye_paypal_marketing_table {
+    padding-right: 20px !important;
 }
 fieldset.pfwma_section_ui {
     border: 1px solid #d1c6c6;
@@ -181,10 +197,13 @@ td a.angelleye_smart_commission_delete {
 }
 
 @media screen and (max-width: 782px) {
+    .angelleye_multi_account_layout {
+        gap: 12px;
+    }
     .angelleye_multi_account_left {
         max-width: 100% !important;
         width: 100%;
-
+        flex-basis: 100%;
     } 
     .micro_account_fields {
         max-width: 100% !important;
@@ -192,7 +211,8 @@ td a.angelleye_smart_commission_delete {
     }
     .angelleye_multi_account_right {
         max-width: 100% !important;
-        width: 95%;
+        width: 100%;
+        flex-basis: 100%;
         margin-left: 0px;
     }
 }

--- a/includes/angelleye-multi-account-function.php
+++ b/includes/angelleye-multi-account-function.php
@@ -187,14 +187,21 @@ function angelleye_get_checkout_custom_field_keys() {
 if (!function_exists('angelleye_is_ppcp_third_party_enable')) {
 
     function angelleye_is_ppcp_third_party_enable($sandbox) {
-        if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
-            include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php';
+        if (function_exists('angelleye_pfw_get_ppcp_settings')) {
+            $settings = angelleye_pfw_get_ppcp_settings();
+            $get_setting = function ($key, $default = '') use ($settings) {
+                return isset($settings[$key]) ? $settings[$key] : $default;
+            };
+        } else {
+            $settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+            $get_setting = function ($key, $default = '') use ($settings) {
+                return isset($settings[$key]) ? $settings[$key] : $default;
+            };
         }
-        $settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
         if ($sandbox) {
-            $sandbox_client_id = $settings->get('sandbox_client_id', '');
-            $sandbox_secret_id = $settings->get('sandbox_api_secret', '');
-            $sandbox_merchant_id = $settings->get('sandbox_merchant_id', '');
+            $sandbox_client_id = $get_setting('sandbox_client_id', '');
+            $sandbox_secret_id = $get_setting('sandbox_api_secret', '');
+            $sandbox_merchant_id = $get_setting('sandbox_merchant_id', '');
             if (!empty($sandbox_client_id) && !empty($sandbox_secret_id)) {
                 return false;
             } else if (!empty($sandbox_merchant_id)) {
@@ -203,9 +210,9 @@ if (!function_exists('angelleye_is_ppcp_third_party_enable')) {
                 return '';
             }
         } else {
-            $live_client_id = $settings->get('api_client_id', '');
-            $live_secret_id = $settings->get('api_secret', '');
-            $live_merchant_id = $settings->get('merchant_id', '');
+            $live_client_id = $get_setting('api_client_id', '');
+            $live_secret_id = $get_setting('api_secret', '');
+            $live_merchant_id = $get_setting('live_merchant_id', '');
             if (!empty($live_client_id) && !empty($live_secret_id)) {
                 return false;
             } else if (!empty($live_merchant_id)) {

--- a/includes/class-paypal-for-woocommerce-multi-account-management-payment-load-balancer.php
+++ b/includes/class-paypal-for-woocommerce-multi-account-management-payment-load-balancer.php
@@ -10,6 +10,8 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Payment_Load_Balancer {
     private $plugin_name;
     private $version;
     public $testmode;
+    public $settings;
+    public $is_sandbox;
 
     public function __construct($plugin_name, $version) {
         $this->plugin_name = $plugin_name;

--- a/includes/class-paypal-for-woocommerce-multi-account-management-payment-load-balancer.php
+++ b/includes/class-paypal-for-woocommerce-multi-account-management-payment-load-balancer.php
@@ -205,11 +205,13 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Payment_Load_Balancer {
     }
 
     public function angelleye_synce_ppcp_account() {
-        if (!class_exists('WC_Gateway_PPCP_AngellEYE_Settings')) {
-            include_once PAYPAL_FOR_WOOCOMMERCE_PLUGIN_DIR . '/ppcp-gateway/class-wc-gateway-ppcp-angelleye-settings.php';
+        if (function_exists('angelleye_pfw_get_ppcp_settings')) {
+            $this->settings = angelleye_pfw_get_ppcp_settings();
+            $this->is_sandbox = 'yes' === angelleye_pfw_get_ppcp_settings('testmode', 'no');
+        } else {
+            $this->settings = get_option('woocommerce_angelleye_ppcp_settings', array());
+            $this->is_sandbox = isset($this->settings['testmode']) && 'yes' === $this->settings['testmode'];
         }
-        $this->settings = WC_Gateway_PPCP_AngellEYE_Settings::instance();
-        $this->is_sandbox = 'yes' === $this->settings->get('testmode', 'no');
         if ($this->is_sandbox) {
             $environment = 'on';
             $option_key = 'angelleye_multi_ppcp_payment_load_balancer_sandbox';

--- a/includes/class-paypal-for-woocommerce-multi-account-management.php
+++ b/includes/class-paypal-for-woocommerce-multi-account-management.php
@@ -141,8 +141,11 @@ class Paypal_For_Woocommerce_Multi_Account_Management {
     private function set_locale() {
 
         $plugin_i18n = new Paypal_For_Woocommerce_Multi_Account_Management_i18n();
-
-        $this->loader->add_action('plugins_loaded', $plugin_i18n, 'load_plugin_textdomain');
+        if (did_action('init')) {
+            $plugin_i18n->load_plugin_textdomain();
+        } else {
+            $this->loader->add_action('init', $plugin_i18n, 'load_plugin_textdomain');
+        }
     }
 
     /**

--- a/includes/class-paypal-for-woocommerce-multi-account-management.php
+++ b/includes/class-paypal-for-woocommerce-multi-account-management.php
@@ -309,10 +309,11 @@ class Paypal_For_Woocommerce_Multi_Account_Management {
     }
 
     public function display_plugin_admin_page() {
-        wp_dequeue_style('woocommerce_admin_styles');
-        $this->display_plugin_admin_page_submenu();
-        echo '<style> .button-primary.woocommerce-save-button { display: none; } </style>';
+        echo '<div class="angelleye_pfwma_admin_shell">';
+        echo '<div class="angelleye_pfwma_admin_content">';
+        echo '<style>.woocommerce-save-button { display: none !important; }</style>';
         $this->plugin_admin->display_admin_notice();
+        $this->display_plugin_admin_page_submenu();
         $section = !empty($_GET['section']) ? $_GET['section'] : '';
         switch ($section) {
             case 'add_edit_account':
@@ -327,12 +328,12 @@ class Paypal_For_Woocommerce_Multi_Account_Management {
             default:
                 $this->plugin_admin->angelleye_multi_account_list();
         }
+        echo '</div></div>';
     }
 
     public function display_plugin_admin_page_submenu() {
         ?>
-        </form>
-        <div class="wrap">
+        <div class="wrap angelleye_pfwma_admin_nav">
             <ul class="subsubsub">
                 <li><a href="<?php echo esc_url(admin_url('admin.php?page=wc-settings&tab=multi_account_management')); ?>" class="<?php
                     if (empty($_GET['section'])) {
@@ -356,11 +357,6 @@ class Paypal_For_Woocommerce_Multi_Account_Management {
                     ?>"><?php echo __('Account Payments Log', 'angelleye-paypal-shipment-tracking-woocommerce'); ?></a>  </li>
             </ul>
             <br class="clear">
-            <?php
-            if (!empty($this->message)) {
-                echo '<div id="message" class="updated inline is-dismissible"><p><strong>' . esc_html($this->message) . '</strong></p></div>';
-            }
-            ?>
         </div>
         <?php
     }

--- a/paypal-for-woocommerce-multi-account-management.php
+++ b/paypal-for-woocommerce-multi-account-management.php
@@ -51,8 +51,10 @@ if (!defined('PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL')) {
     define('PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL', 'https://www.angelleye.com/');
 }
 
-if (!defined('MULTI_ACCOUNT_REFUND_NOTICE')) {
-    define('MULTI_ACCOUNT_REFUND_NOTICE', __('Partial refunds are not available for parallel payments orders.', 'paypal-for-woocommerce-multi-account-management'));
+if (!function_exists('angelleye_pfwma_get_multi_account_refund_notice')) {
+    function angelleye_pfwma_get_multi_account_refund_notice() {
+        return __('Partial refunds are not available for parallel payments orders.', 'paypal-for-woocommerce-multi-account-management');
+    }
 }
 
 


### PR DESCRIPTION
**Description**  
This PR stabilizes the `paypal-for-woocommerce-multi-account-management` admin UI after recent compatibility changes.

### What was fixed

- Kept WooCommerce admin styles enabled on Multi-Account settings pages.
- Removed fragile markup assumptions in custom tab shell rendering.
- Standardized tab rendering order so notices appear first, then tab navigation, then tab content across sections.
- Hid WooCommerce’s default bottom “Save changes” button reliably on Multi-Account tab pages.
- Fixed marketing sidebar rendering to `All PayPal Accounts`.

### Why

The settings UI was showing inconsistent tab/header placement, occasional broken wrapper behavior, and unwanted Woo default save button visibility. This PR makes the Multi-Account admin pages structurally consistent and predictable across all sections while preserving existing save logic and gateway behavior.

### Validation

- Manually validated expected UI behavior across:
  - `All PayPal Accounts`
  - `Add / Edit Accounts`
  - `Settings`
  - `Account Payments Log`