### PR TITLE
Fix - Rounding adjustment unconditionally removes shipping/tax breakdown

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -1624,28 +1624,34 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
             if (abs($Difference) > 0.000001 && 0.0 !== (float) $Difference) {
                 if (isset($new_payments[0]['amt']) && $new_payments[0]['amt'] > 1) {
                     $new_payments[0]['amt'] = $new_payments[0]['amt'] + $Difference;
-                    $item_names = array();
-                    if (!empty($new_payments[0]['items'])) {
-                        $first_line_item = $new_payments[0]['items'];
-                    }
-                    if (!empty($first_line_item)) {
-                        unset($new_payments[0]['items']);
-                        $new_payments[0]['items'] = array();
-                        $new_payments[0]['itemamt'] = $new_payments[0]['amt'];
-                        foreach ($first_line_item as $key => $value) {
-                            $item_names[] = $value['name'] . ' x ' . $value['qty'];
+                    if (isset($new_payments[0]['taxamt']) && $new_payments[0]['taxamt'] > 1) {
+                        $new_payments[0]['taxamt'] = $new_payments[0]['taxamt'] + $Difference;
+                    } elseif (isset($new_payments[0]['shippingamt']) && $new_payments[0]['shippingamt'] > 1) {
+                        $new_payments[0]['shippingamt'] = $new_payments[0]['shippingamt'] + $Difference;
+                    } else {
+                        $item_names = array();
+                        if (!empty($new_payments[0]['items'])) {
+                            $first_line_item = $new_payments[0]['items'];
                         }
-                        $item_details = implode(', ', $item_names);
-                        $item_details = html_entity_decode(wc_trim_string($item_details ? wp_strip_all_tags($item_details) : __('Item', 'paypal-for-woocommerce-multi-account-management'), 127), ENT_NOQUOTES, 'UTF-8');
-                        $new_payments[0]['items'][0] = array(
-                            'name' => $item_details,
-                            'desc' => '',
-                            'amt' => AngellEYE_Gateway_Paypal::number_format($new_payments[0]['amt']),
-                            'qty' => 1
-                        );
+                        if (!empty($first_line_item)) {
+                            unset($new_payments[0]['items']);
+                            $new_payments[0]['items'] = array();
+                            $new_payments[0]['itemamt'] = $new_payments[0]['amt'];
+                            foreach ($first_line_item as $key => $value) {
+                                $item_names[] = $value['name'] . ' x ' . $value['qty'];
+                            }
+                            $item_details = implode(', ', $item_names);
+                            $item_details = html_entity_decode(wc_trim_string($item_details ? wp_strip_all_tags($item_details) : __('Item', 'paypal-for-woocommerce-multi-account-management'), 127), ENT_NOQUOTES, 'UTF-8');
+                            $new_payments[0]['items'][0] = array(
+                                'name' => $item_details,
+                                'desc' => '',
+                                'amt' => AngellEYE_Gateway_Paypal::number_format($new_payments[0]['amt']),
+                                'qty' => 1
+                            );
+                        }
+                        unset($new_payments[0]['shippingamt']);
+                        unset($new_payments[0]['taxamt']);
                     }
-                    unset($new_payments[0]['shippingamt']);
-                    unset($new_payments[0]['taxamt']);
                 }
             }
         }
@@ -1708,6 +1714,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
             $old_wc = version_compare(WC_VERSION, '3.0', '<');
             if (!empty($new_payments)) {
                 foreach ($new_payments as $key_new_payments => $value_new_payments) {
+                    $update_amount_request = array();
                     if (!empty($value_new_payments['itemamt'])) {
                         $update_amount_request['item_total'] = array(
                             'currency_code' => angelleye_ppcp_get_currency($order_id),


### PR DESCRIPTION

### Root Cause

**Bug 1 — Rounding adjustment unconditionally removes shipping/tax breakdown**

In `angelleye_modified_ppcp_parallel_parameter()`, when a small rounding difference exists between calculated and expected order totals (e.g., `134.99` vs `135.00`), the code:
1. Correctly adds the difference to `amt` ✓
2. Collapses all items into a single line item ✗
3. Unconditionally `unset()` both `shippingamt` and `taxamt` ✗

This destroys the amount breakdown, causing PayPal to see no shipping component.

The Express Checkout class already handled this correctly with a three-tier approach — the PPCP class was missing this logic.

**Bug 2 — `$update_amount_request` not initialized per loop iteration**

In the `update_order` code path, the `$update_amount_request` variable was never reset between loop iterations. This caused subsequent purchase units to inherit the previous unit's shipping/tax breakdown in the PATCH request, corrupting multi-account order updates.

### Fix

**Bug 1:** Replaced the unconditional collapse with a three-tier rounding absorption (matching the existing Express Checkout implementation):
1. If `taxamt > 1` → absorb the rounding difference into `taxamt`
2. Else if `shippingamt > 1` → absorb into `shippingamt`
3. Only as a last resort → collapse into single line item and unset both

This keeps the breakdown balanced: `amt = itemamt + shippingamt + taxamt - discount`

**Bug 2:** Added `$update_amount_request = array();` at the start of each `foreach` iteration in the `update_order` path.

### Files Changed

- `admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php`

### Testing

- [ ] Place an order with product + shipping using PPCP with multi-account enabled
- [ ] Verify PayPal captures the full amount (product + shipping)
- [ ] Verify PayPal transaction breakdown shows correct shipping amount
- [ ] Test with multiple accounts where only one account's products have shipping
- [ ] Test order update flow (e.g., shipping method changed on review page)
