### PR TITLE
Fix shipping amount not captured in PPCP multi-account payments

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-express-checkout.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-express-checkout.php
@@ -1986,7 +1986,9 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_Express_Checkout {
                                 unset($partition_array[$loop]);
                                 $loop = $loop + 1;
                             } else {
-                                $partition_array[$product_id] = isset($item_with_account['shipping_cost']) ? $item_with_account['shipping_cost'] : $partition_array[$loop];
+                                $partition_array[$product_id] = $partition_array[$loop];
+                                unset($partition_array[$loop]);
+                                $loop = $loop + 1;
                             }
                         }
                         break;

--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -1995,7 +1995,9 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
                                 unset($partition_array[$loop]);
                                 $loop++;
                             } else {
-                                $partition_array[$product_id] = $item_with_account['shipping_cost'] ?? $partition_array[$loop];
+                                $partition_array[$product_id] = $partition_array[$loop];
+                                unset($partition_array[$loop]);
+                                $loop++;
                             }
                         }
                         break;


### PR DESCRIPTION
### Problem

Orders processed through PPCP with the Multi-Account Management plugin were being captured without shipping amounts. For example, an order with $110 product + $25 shipping = $135 total would only capture $110 on PayPal.

### Root Cause

Three bugs working together:

**Bug 1 — Rounding adjustment strips shipping/tax breakdown (PPCP)**
`admin/class-...-admin-ppcp.php` ~line 1622

When a small rounding difference existed between calculated and expected totals (e.g., `134.99` vs `135.00`), the code added the difference to `amt` but then unconditionally `unset()` both `shippingamt` and `taxamt`, collapsing everything into a single line item. The Express Checkout class already handled this correctly with a three-tier approach — the PPCP class was missing this logic.

Before (broken):
```
amt = 135.00, itemamt = 135.00, shipping = (missing), tax = (missing)
```

After (fixed):
```
amt = 135.00, itemamt = 109.99, shipping = 25.01, tax = 0.00
```

**Bug 2 — `$update_amount_request` not initialized per loop iteration (PPCP)**
`admin/class-...-admin-ppcp.php` ~line 1714

In the `update_order` PATCH path, `$update_amount_request` was never reset between loop iterations. This caused subsequent purchase units to inherit the previous unit's shipping/tax breakdown, corrupting the PATCH request. Since `update_order` overwrites the `create_order` amounts, this could reduce the captured amount to just the item total.

**Bug 3 — Shipping allocation `else` branch missing `$loop++` and `unset` (PPCP + Express Checkout)**
`admin/class-...-admin-ppcp.php` ~line 1997
`admin/class-...-admin-express-checkout.php` ~line 1988

When products need shipping but have no per-product `shipping_cost` set (common with table rate, simple flat rate), the `else` branch in `angelleye_get_extra_fee_array()` assigned the partition value but never incremented `$loop` or consumed the numeric key. This caused `$shipping_array` to be miskeyed, resulting in `$this->shipping_array[$product_id]` returning `'0.00'` — the root cause of shipping being excluded from payment amounts.

### Changes

| File | Fix |
|------|-----|
| `admin/class-...-admin-ppcp.php` | Bug 1: Three-tier rounding absorption (tax → shipping → collapse) matching Express Checkout |
| `admin/class-...-admin-ppcp.php` | Bug 2: Initialize `$update_amount_request = array()` per loop iteration |
| `admin/class-...-admin-ppcp.php` | Bug 3: Add `unset()` and `$loop++` to shipping else branch |
| `admin/class-...-admin-express-checkout.php` | Bug 3: Same fix as PPCP |

### Testing

- [ ] Order with product + shipping via PPCP multi-account → verify full amount captured
- [ ] Verify PayPal transaction breakdown shows correct shipping amount
- [ ] Order with multiple products across different accounts, mixed shipping requirements
- [ ] Order using table rate / simple flat rate shipping (no per-product shipping_cost)
- [ ] Order update flow (shipping method changed on review page)
- [ ] Express Checkout order with shipping to verify Bug 3 fix
