### PR TITLE
Fix AMOUNT_MISMATCH issue  with large coupons leaving a small cart total

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -1651,6 +1651,7 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
                         }
                         unset($new_payments[0]['shippingamt']);
                         unset($new_payments[0]['taxamt']);
+                        unset($new_payments[0]['discount']);
                     }
                 }
             }


### PR DESCRIPTION
When a coupon discount distribution produced a rounding mismatch between final_grand_total and final_order_grand_total, and the first purchase unit had no shipping or tax to absorb the difference, the fallback in angelleye_modified_ppcp_parallel_parameter() consolidated line items into a single item and set itemamt = amt (the post-discount total) but left the existing breakdown.discount field in place. PayPal then rejected the order because amount no longer equaled item_total - discount.

Clear the stale discount field alongside shippingamt/taxamt so the consolidated single-item purchase unit reconciles cleanly.

Express Checkout encodes discounts as a negative line item inside order_items rather than a separate field, so the same fallback there is unaffected.
