### PR TITLE
Use common AngellEye Push Notification

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin.php
@@ -2424,48 +2424,6 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin {
         return null;
     }
 
-    public function angelleye_paypal_for_woocommerce_multi_account_display_push_notification() {
-        global $current_user;
-        $user_id = $current_user->ID;
-        $response = $this->angelleye_get_push_notifications();
-        if (is_object($response)) {
-            foreach ($response->data as $key => $response_data) {
-                if (!get_user_meta($user_id, $response_data->id)) {
-                    $this->angelleye_display_push_notification($response_data);
-                }
-            }
-        }
-    }
-
-    public function angelleye_get_push_notifications() {
-        return AngellEYE_Utility::angelleye_get_push_notifications('paypal-for-woocommerce-multi-account-management');
-    }
-
-    public function angelleye_display_push_notification($response_data) {
-        echo '<div class="notice notice-success angelleye-notice" style="display:none;" id="' . $response_data->id . '">'
-        . '<div class="angelleye-notice-logo-push"><span> <img src="' . $response_data->ans_company_logo . '"> </span></div>'
-        . '<div class="angelleye-notice-message">'
-        . '<h3>' . $response_data->ans_message_title . '</h3>'
-        . '<div class="angelleye-notice-message-inner">'
-        . '<p>' . $response_data->ans_message_description . '</p>'
-        . '<div class="angelleye-notice-action"><a target="_blank" href="' . $response_data->ans_button_url . '" class="button button-primary">' . $response_data->ans_button_label . '</a></div>'
-        . '</div>'
-        . '</div>'
-        . '<div class="angelleye-notice-cta">'
-        . '<button class="angelleye-notice-dismiss angelleye-dismiss-welcome" data-msg="' . $response_data->id . '">Dismiss</button>'
-        . '</div>'
-        . '</div>';
-    }
-
-    public function angelleye_paypal_for_woocommerce_multi_account_adismiss_notice() {
-        global $current_user;
-        $user_id = $current_user->ID;
-        if (!empty($_POST['action']) && $_POST['action'] == 'angelleye_paypal_for_woocommerce_multi_account_adismiss_notice') {
-            add_user_meta($user_id, wc_clean($_POST['data']), 'true', true);
-            wp_send_json_success();
-        }
-    }
-
     public function angelleye_set_multi_account($token_id, $order_id) {
         if (!empty($token_id)) {
             $_multi_account_api_username = get_metadata('payment_token', $token_id, '_multi_account_api_username');

--- a/admin/js/paypal-for-woocommerce-multi-account-management-admin.js
+++ b/admin/js/paypal-for-woocommerce-multi-account-management-admin.js
@@ -208,22 +208,7 @@ jQuery(function () {
     jQuery('[id^=angelleye_notification]').each(function (i) {
         jQuery('[id="' + this.id + '"]').slice(1).remove();
     });
-    var el_notice = jQuery(".angelleye-notice");
-    el_notice.fadeIn(750);
-    jQuery(".angelleye-notice-dismiss").click(function (e) {
-        e.preventDefault();
-        jQuery(this).parent().parent(".angelleye-notice").fadeOut(600, function () {
-            jQuery(this).parent().parent(".angelleye-notice").remove();
-        });
-        notify_wordpress(jQuery(this).data("msg"));
-    });
-    function notify_wordpress(message) {
-        var param = {
-            action: 'angelleye_paypal_for_woocommerce_multi_account_adismiss_notice',
-            data: message
-        };
-        jQuery.post(ajaxurl, param);
-    }
+    jQuery(".angelleye-notice").fadeIn(750);
 });
 jQuery(document).off('click', '#angelleye-updater-notice .notice-dismiss').on('click', '#angelleye-updater-notice .notice-dismiss', function (event) {
     var r = confirm("If you do not install the Updater plugin you will not receive automated updates for Angell EYE products going forward!");

--- a/includes/class-paypal-for-woocommerce-multi-account-management.php
+++ b/includes/class-paypal-for-woocommerce-multi-account-management.php
@@ -169,8 +169,6 @@ class Paypal_For_Woocommerce_Multi_Account_Management {
         $this->loader->add_action('woocommerce_cart_emptied', $plugin_admin, 'remove_session_data', 9999);
         $this->loader->add_action('wp_ajax_angelleye_pfwma_get_product_tags', $plugin_admin, 'angelleye_pfwma_get_product_tags', 10);
         $this->loader->add_action('wp_ajax_angelleye_pfwma_get_products', $plugin_admin, 'angelleye_pfwma_get_products', 10);
-        $this->loader->add_action('wp_ajax_angelleye_paypal_for_woocommerce_multi_account_adismiss_notice', $plugin_admin, 'angelleye_paypal_for_woocommerce_multi_account_adismiss_notice', 10);
-        $this->loader->add_action('admin_notices', $plugin_admin, 'angelleye_paypal_for_woocommerce_multi_account_display_push_notification', 10);
         $this->loader->add_action('angelleye_set_multi_account', $plugin_admin, 'angelleye_set_multi_account', 10, 2);
         $this->loader->add_filter('set-screen-option', $plugin_admin, 'angelleye_set_screen_option', 10, 3);
         $this->loader->add_action('load-settings_page_paypal-for-woocommerce', $plugin_admin, 'angelleye_add_screen_option', 10);

--- a/includes/notifications/class-angelleye-push-notifications.php
+++ b/includes/notifications/class-angelleye-push-notifications.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * AngellEYE Push Notifications.
+ *
+ * Self-contained reusable class for fetching and displaying admin notifications
+ * pushed from angelleye.com. Designed to be copy-pasted into any AngellEYE plugin.
+ *
+ * Usage in a plugin's bootstrap:
+ *
+ *     require_once __DIR__ . '/includes/notifications/class-angelleye-push-notifications.php';
+ *     add_action( 'plugins_loaded', function () {
+ *         ( new AngellEYE_Push_Notifications( array(
+ *             'plugin_slug' => 'my-plugin-slug',
+ *         ) ) )->register();
+ *     }, 25 );
+ *
+ * Optional config:
+ *   - api_url       (string)   Override the remote endpoint base.
+ *   - timeout       (int)      HTTP timeout in seconds. Default 5.
+ *   - success_ttl   (int)      Cache TTL on success. Default 12 hours.
+ *   - failure_ttl   (int)      Cache TTL on failure. Default 4 hours.
+ *   - applies_to    (callable) fn( $notification, $plugin_slug ): bool — filter which
+ *                              notifications are shown to the current admin.
+ *
+ * @package angelleye-shared
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'AngellEYE_Push_Notifications' ) ) {
+
+    class AngellEYE_Push_Notifications {
+
+        const VERSION    = '1.0.0';
+        const API_BASE   = 'https://www.angelleye.com/';
+        const USER_AGENT = 'AngellEYE';
+
+        private $plugin_slug;
+        private $api_url;
+        private $timeout;
+        private $success_ttl;
+        private $failure_ttl;
+        private $applies_to;
+        private $dismiss_action;
+
+        private static $script_printed = false;
+
+        public function __construct( array $args ) {
+            if ( empty( $args['plugin_slug'] ) ) {
+                _doing_it_wrong( __METHOD__, 'plugin_slug is required.', '1.0.0' );
+                $args['plugin_slug'] = 'unknown';
+            }
+            $this->plugin_slug    = sanitize_key( $args['plugin_slug'] );
+            $this->api_url        = isset( $args['api_url'] ) ? $args['api_url'] : self::API_BASE;
+            $this->timeout        = isset( $args['timeout'] ) ? (int) $args['timeout'] : 5;
+            $this->success_ttl    = isset( $args['success_ttl'] ) ? (int) $args['success_ttl'] : 12 * HOUR_IN_SECONDS;
+            $this->failure_ttl    = isset( $args['failure_ttl'] ) ? (int) $args['failure_ttl'] : 4 * HOUR_IN_SECONDS;
+            $this->applies_to     = isset( $args['applies_to'] ) && is_callable( $args['applies_to'] ) ? $args['applies_to'] : null;
+            $this->dismiss_action = 'angelleye_dismiss_notice_' . $this->plugin_slug;
+        }
+
+        public function register() {
+            add_action( 'admin_notices', array( $this, 'display_admin_notices' ) );
+            add_action( 'wp_ajax_' . $this->dismiss_action, array( $this, 'handle_dismiss' ) );
+            add_action( 'admin_print_footer_scripts', array( $this, 'print_dismiss_script' ) );
+        }
+
+        /**
+         * Fetch push notifications, with success + failure transient caching.
+         *
+         * @return object|false
+         */
+        public function get_push_notifications() {
+            $success_key = $this->transient_key( 'success' );
+            $failure_key = $this->transient_key( 'failure' );
+
+            $cached = get_transient( $success_key );
+            if ( false !== $cached ) {
+                return $cached;
+            }
+            if ( false !== get_transient( $failure_key ) ) {
+                return false;
+            }
+
+            $endpoint = trailingslashit( $this->api_url ) . '?Wordpress_Plugin_Notification_Sender&action=angelleye_get_plugin_notification';
+
+            $response = wp_remote_post( $endpoint, array(
+                'method'      => 'POST',
+                'timeout'     => $this->timeout,
+                'redirection' => 5,
+                'httpversion' => '1.0',
+                'blocking'    => true,
+                'headers'     => array( 'user-agent' => self::USER_AGENT ),
+                'body'        => array( 'plugin_name' => $this->plugin_slug ),
+                'cookies'     => array(),
+                'sslverify'   => false,
+            ) );
+
+            if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+                set_transient( $failure_key, time(), $this->failure_ttl );
+                return false;
+            }
+
+            $body   = wp_remote_retrieve_body( $response );
+            $parsed = $body ? json_decode( $body ) : false;
+
+            if ( $parsed ) {
+                set_transient( $success_key, $parsed, $this->success_ttl );
+                delete_transient( $failure_key );
+                return $parsed;
+            }
+
+            set_transient( $failure_key, time(), $this->failure_ttl );
+            return false;
+        }
+
+        public function display_admin_notices() {
+            if ( ! is_user_logged_in() ) {
+                return;
+            }
+
+            $response = $this->get_push_notifications();
+            if ( ! is_object( $response ) || empty( $response->data ) || ! is_array( $response->data ) ) {
+                return;
+            }
+
+            $user_id = get_current_user_id();
+
+            foreach ( $response->data as $notification ) {
+                if ( empty( $notification->id ) ) {
+                    continue;
+                }
+                if ( get_user_meta( $user_id, $notification->id, true ) ) {
+                    continue;
+                }
+                if ( $this->applies_to && ! call_user_func( $this->applies_to, $notification, $this->plugin_slug ) ) {
+                    continue;
+                }
+                $this->render_notification( $notification );
+            }
+        }
+
+        public function render_notification( $n ) {
+            $id          = isset( $n->id ) ? $n->id : '';
+            $logo        = isset( $n->ans_company_logo ) ? $n->ans_company_logo : '';
+            $title       = isset( $n->ans_message_title ) ? $n->ans_message_title : '';
+            $description = isset( $n->ans_message_description ) ? $n->ans_message_description : '';
+            $btn_url     = isset( $n->ans_button_url ) ? $n->ans_button_url : '';
+            $btn_label   = isset( $n->ans_button_label ) ? $n->ans_button_label : '';
+            ?>
+            <div class="notice notice-success angelleye-notice" style="display:none;" id="<?php echo esc_attr( $id ); ?>" data-angelleye-action="<?php echo esc_attr( $this->dismiss_action ); ?>">
+                <?php if ( $logo ) : ?>
+                <div class="angelleye-notice-logo-push"><span><img alt="" src="<?php echo esc_url( $logo ); ?>" /></span></div>
+                <?php endif; ?>
+                <div class="angelleye-notice-message">
+                    <h3><?php echo esc_html( $title ); ?></h3>
+                    <div class="angelleye-notice-message-inner">
+                        <p><?php echo esc_html( $description ); ?></p>
+                        <?php if ( $btn_url && $btn_label ) : ?>
+                        <div class="angelleye-notice-action">
+                            <a target="_blank" href="<?php echo esc_url( $btn_url ); ?>" class="button button-primary"><?php echo esc_html( $btn_label ); ?></a>
+                        </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="angelleye-notice-cta">
+                    <button type="button" class="angelleye-notice-dismiss angelleye-dismiss-welcome" data-msg="<?php echo esc_attr( $id ); ?>" data-action="<?php echo esc_attr( $this->dismiss_action ); ?>">Dismiss</button>
+                </div>
+            </div>
+            <?php
+        }
+
+        public function handle_dismiss() {
+            if ( ! is_user_logged_in() ) {
+                wp_send_json_error();
+            }
+            $message_id = isset( $_POST['data'] ) ? wc_clean( wp_unslash( $_POST['data'] ) ) : '';
+            if ( '' === $message_id ) {
+                wp_send_json_error();
+            }
+            add_user_meta( get_current_user_id(), $message_id, 'true', true );
+            wp_send_json_success();
+        }
+
+        /**
+         * Print one inline dismiss handler that works for every AngellEYE_Push_Notifications
+         * instance on the page (each notice carries its own data-action).
+         */
+        public function print_dismiss_script() {
+            if ( self::$script_printed ) {
+                return;
+            }
+            self::$script_printed = true;
+            ?>
+            <script type="text/javascript">
+            (function ($) {
+                $(document).on('click', '.angelleye-notice-dismiss', function (e) {
+                    e.preventDefault();
+                    var $btn   = $(this);
+                    var msg    = $btn.data('msg');
+                    var action = $btn.data('action');
+                    if (!action) { return; }
+                    $btn.closest('.angelleye-notice').fadeOut(600, function () { $(this).remove(); });
+                    $.post(ajaxurl, { action: action, data: msg });
+                });
+            })(jQuery);
+            </script>
+            <?php
+        }
+
+        private function transient_key( $type ) {
+            return 'angelleye_push_notification_' . $type . '_' . md5( $this->plugin_slug );
+        }
+    }
+}

--- a/paypal-for-woocommerce-multi-account-management.php
+++ b/paypal-for-woocommerce-multi-account-management.php
@@ -170,3 +170,13 @@ add_action( 'before_woocommerce_init', function() {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 	}
 } );
+
+require_once plugin_dir_path(__FILE__) . 'includes/notifications/class-angelleye-push-notifications.php';
+add_action('plugins_loaded', function () {
+    if (!is_admin() || !class_exists('AngellEYE_Push_Notifications')) {
+        return;
+    }
+    (new AngellEYE_Push_Notifications(array(
+        'plugin_slug' => 'paypal-for-woocommerce-multi-account-management',
+    )))->register();
+}, 25);


### PR DESCRIPTION
## Summary

Migrates `paypal-for-woocommerce-multi-account-management` to the shared `AngellEYE_Push_Notifications` class, matching the pattern already adopted by `paypal-for-woocommerce`, `PayPal-Invoicing-for-WordPress`, `offers-for-woocommerce`, and `paypal-shipment-tracking-for-woocommerce`. The plugin now uses one canonical, self-contained notifications implementation instead of its own divergent copy.

## Changes

- **Add** `includes/notifications/class-angelleye-push-notifications.php` — copied verbatim from `paypal-for-woocommerce`. The file is `class_exists`-guarded, so whichever sibling plugin loads first wins and the rest no-op.
- **Bootstrap wiring** in `paypal-for-woocommerce-multi-account-management.php` — `require_once` the shared class and instantiate it on `plugins_loaded` with `plugin_slug => 'paypal-for-woocommerce-multi-account-management'`, identical to how the four sibling plugins register.
- **Remove** the per-plugin push-notification methods from `admin/class-paypal-for-woocommerce-multi-account-management-admin.php`:
  - `angelleye_paypal_for_woocommerce_multi_account_display_push_notification()`
  - `angelleye_get_push_notifications()`
  - `angelleye_display_push_notification()`
  - `angelleye_paypal_for_woocommerce_multi_account_adismiss_notice()`
- **Remove** the corresponding hook registrations in `includes/class-paypal-for-woocommerce-multi-account-management.php` — the shared class registers its own `admin_notices`, `wp_ajax_*`, and `admin_print_footer_scripts` hooks.
- **Trim** `admin/js/paypal-for-woocommerce-multi-account-management-admin.js` — keep the `fadeIn(750)` for `.angelleye-notice` (still required since the shared class renders notices with `display:none`); drop the old dismiss click handler and AJAX POST to the now-removed `angelleye_paypal_for_woocommerce_multi_account_adismiss_notice` action. The shared class prints its own inline dismiss handler keyed on `data-action`.

## Why this approach

The shared class is the established convention across the AngellEYE plugin family:

- One implementation to maintain (caching, dismiss, rendering, AJAX handling) instead of N divergent copies.
- The dismiss script is printed once per page via a static guard, so multiple AngellEYE plugins active on the same site won't double-bind handlers.
- The class supports an optional `applies_to` callback for plugins that need conditional notice display (e.g. only when a specific WC gateway is enabled), giving us a clean extension point if multi-account ever needs targeting.

## Test plan

- [ ] Activate the plugin alongside `paypal-for-woocommerce` and confirm no `class AngellEYE_Push_Notifications cannot be redeclared` errors (the `class_exists` guard handles this).
- [ ] Load any wp-admin page and confirm no PHP fatals or warnings related to push notifications.
- [ ] Confirm push notifications targeted at the `paypal-for-woocommerce-multi-account-management` slug render in the admin notices area and fade in.
- [ ] Click "Dismiss" on a notification and confirm:
  - The notice fades out.
  - A POST to `admin-ajax.php` fires with `action=angelleye_dismiss_notice_paypal-for-woocommerce-multi-account-management` and returns `success: true`.
  - The notice does not reappear on subsequent admin page loads for the same user (user meta entry recorded).
- [ ] Verify the existing required-plugin admin notice (WooCommerce / PayPal for WooCommerce inactive) still renders correctly — that hook is unchanged.
- [ ] Activate two or more AngellEYE plugins that use the shared class on the same site and confirm only one inline dismiss handler is printed in the page footer.
