### PR TITLE
Fix payee mismatch error on order-pay page for multi-payee orders

### DIFF
--- a/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
+++ b/admin/class-paypal-for-woocommerce-multi-account-management-admin-ppcp.php
@@ -2992,10 +2992,34 @@ class Paypal_For_Woocommerce_Multi_Account_Management_Admin_PPCP {
     }
 
     public function angelleye_get_product_ids() {
-        global $post;
+        global $post, $wp;
         $product_ids = array();
         if (is_product()) {
             $product_ids[] = $post->ID;
+        }
+        // On the order-pay page the cart is empty, so the merchant-id list must be
+        // derived from the order being paid. Otherwise angelleye_get_list_merchant_ids()
+        // returns false, the SDK loads without the order's payee(s), and PayPal returns
+        // a "Payee(s) passed in transaction does not match expected merchant id" error.
+        if (function_exists('is_checkout_pay_page') && is_checkout_pay_page()) {
+            $order_id = 0;
+            if (!empty($wp->query_vars['order-pay'])) {
+                $order_id = absint($wp->query_vars['order-pay']);
+            } elseif (!empty($_GET['order-pay'])) {
+                $order_id = absint(wp_unslash($_GET['order-pay']));
+            }
+            if ($order_id > 0) {
+                $order = wc_get_order($order_id);
+                if ($order instanceof WC_Order) {
+                    foreach ($order->get_items() as $item) {
+                        $item_product_id = $item->get_product_id();
+                        if (!empty($item_product_id)) {
+                            $product_ids[] = $item_product_id;
+                        }
+                    }
+                    return $product_ids;
+                }
+            }
         }
         if (is_null(WC()->cart)) {
             return $product_ids;


### PR DESCRIPTION
## Summary

Fixes the PayPal error on the WooCommerce **order-pay** page for multi-account (parallel/commission) orders:

> Payee(s) passed in transaction does not match expected merchant id. Please ensure you are passing merchant-id=* to the sdk url and data-merchant-id="…" in the sdk script tag.

## Root cause

The SDK `merchant-id` / `data-merchant-id` list is derived from `angelleye_get_product_ids()`, which only reads product IDs from `is_product()` or `WC()->cart` — it has no order-pay branch. On the order-pay page the cart is empty, so:

1. `angelleye_get_product_ids()` returns `[]`.
2. `angelleye_get_list_merchant_ids()` returns `false` → `sdk_merchant_id = false`.
3. The PayPal SDK loads without `merchant-id` / `data-merchant-id`.
4. But the PayPal order is still built from the order line items with multiple payees (mapped seller + commission/owner account).
5. PayPal validates the order's payees against the SDK's declared merchants, finds none, and throws the error.

## Change

`angelleye_get_product_ids()` now falls back to the **order's line items** when on the order-pay page (`is_checkout_pay_page()`): it resolves the order ID from `$wp->query_vars['order-pay']` (or the `order-pay` query arg), loads the order, and collects `get_product_id()` from each item. Those IDs flow through the existing merchant-id resolution chain, so `data-merchant-id` matches the order's payees.

- Cart / product-page paths are unchanged.
- `merchant-id=*` is **not** hardcoded — the existing 2+-id logic emits it automatically once the list is populated.

## Testing

1. Enable PFWMA with product→account mapping so an order splits across two payees (or has site-owner commission enabled).
2. Place an order that stays unpaid so a `Pay for order` link is generated.
3. Open the order-pay page and pay with PayPal.
4. Before: "Payee(s) … does not match expected merchant id". After: payment completes.

## Out of scope

Load-balancer mode resolves merchants via round-robin (`angelleye_get_merchant_ids_from_load_balancer()`), not product IDs, so it is untouched by this fix and tracked separately.

Fixes #135